### PR TITLE
Fix undefined files error

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,11 @@ function glslifyWebpackLoader(source) {
     inline: true,
     basedir: basedir
   }, function(err, src, files) {
-    files.forEach(function(file) {
-      self.addDependency(file)
-    })
+    if (files) {
+      files.forEach(function(file) {
+        self.addDependency(file)
+      })
+    }
 
     return self.callback(err, src)
   })


### PR DESCRIPTION
If an error was encountered during `glslify.bundle` then `files` may be `undefined` which will throw an error instead of propagating the error back to webpack
