### PR TITLE
Pass query options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,21 @@
-const glslify = require('glslify')
-const path    = require('path')
+const loaderUtils = require('loader-utils')
+const glslify     = require('glslify')
+const path        = require('path')
 
 module.exports = glslifyWebpackLoader
 
 function glslifyWebpackLoader(source) {
   var basedir = path.dirname(this.resourcePath)
+  var opts = loaderUtils.parseQuery(this.query)
   var self = this
+
+  opts.inline = true
+  opts.basedir = basedir
 
   this.callback = this.async()
   this.cacheable(true)
 
-  glslify.bundle(source, {
-    inline: true,
-    basedir: basedir
-  }, function(err, src, files) {
+  glslify.bundle(source, opts, function(err, src, files) {
     if (files) {
       files.forEach(function(file) {
         self.addDependency(file)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "url": "http://hughsk.io/"
   },
   "dependencies": {
-    "glslify": "^2.1.1"
+    "glslify": "^2.1.1",
+    "loader-utils": "^0.2.12"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
Add ability to pass transforms.

How to use example: 

``` js
{
    test: /\.(glsl|vert|frag)$/,
    loader: 'raw!glslify-loader?transform[]=glslify-import'
}
```
