### PR TITLE
Update README for Webpack 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ like so to have them bundled at build time:
 var source = require('glslify!raw!./my-shader.glsl')
 ```
 
+For Webpack 2 do:
+``` javascript
+var source = require('raw-loader!glslify-loader!./my-shader.glsl')
+```
+
 ### Configuration
 
 Alternatively, you may apply these loaders automatically


### PR DESCRIPTION
Our internal application is running Webpack 2.4.1, and apparently for the transforms to work they need to be reversed and have `-loader` added to their names.