### PR TITLE
fix: use webpack 3.x/4.x config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![experimental](http://badges.github.io/stability-badges/dist/experimental.svg)](http://github.com/badges/stability-badges)
 
-[glslify](http://github.com/stackgl/glslify) loader module for [webpack](http://webpack.github.io/).
+[glslify](http://github.com/stackgl/glslify) loader module for [webpack](https://webpack.js.org).
 
 ## Installation
 
@@ -13,17 +13,22 @@ Generally, you'll want to use this alongside webpack's
 npm install --save glslify-loader raw-loader
 ```
 
+Alternatively, using `yarn`:
+``` bash
+yarn glslify-loader raw-loader
+```
+
 ## Usage
 
 [![NPM](https://nodei.co/npm/glslify-loader.png)](https://nodei.co/npm/glslify-loader/)
 
-[Documentation: Using Loaders](http://webpack.github.io/docs/using-loaders.html)
+[Documentation: Using Loaders](https://webpack.js.org/concepts/loaders/#using-loaders)
 
 Once installed, you should be able to require your shaders
 like so to have them bundled at build time:
 
 ``` javascript
-var source = require('glslify!raw!./my-shader.glsl')
+var source = require('glslify-loader!raw-loader!./my-shader.glsl')
 ```
 
 ### Configuration
@@ -35,9 +40,17 @@ additional configuration:
 ``` javascript
 module.exports = {
   module: {
-    loaders: [
-      { test: /\.(glsl|frag|vert)$/, loader: 'raw', exclude: /node_modules/ },
-      { test: /\.(glsl|frag|vert)$/, loader: 'glslify', exclude: /node_modules/ }
+    rules: [
+      { 
+        test: /\.(glsl|frag|vert)$/, 
+        loader: 'raw-loader', 
+        exclude: /node_modules/ 
+      },
+      { 
+        test: /\.(glsl|frag|vert)$/, 
+        loader: './index', 
+        exclude: /node_modules/ 
+      }
     ]
   }
 }

--- a/entry.js
+++ b/entry.js
@@ -1,2 +1,2 @@
-document.querySelector('[name="orig"]').value = require('!!raw!./example.frag')
+document.querySelector('[name="orig"]').value = require('!!raw-loader!./example.frag')
 document.querySelector('[name="post"]').value = require('./example.frag')

--- a/index.js
+++ b/index.js
@@ -10,16 +10,13 @@ function glslifyWebpackLoader(source) {
   this.callback = this.async()
   this.cacheable(true)
 
-  glslify.bundle(source, {
-    inline: true,
-    basedir: basedir
-  }, function(err, src, files) {
-    if (files) {
-      files.forEach(function(file) {
-        self.addDependency(file)
-      })
-    }
-
-    return self.callback(err, src)
-  })
+  try {
+    const comp = glslify.compile(source, {
+      inline: true,
+      basedir: basedir
+    });
+    self.callback(null, comp);
+  } catch (e) {
+    self.callback(e, '');
+  }
 }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function glslifyWebpackLoader(source) {
   this.cacheable(true)
 
   try {
-    const comp = glslify.compile(source, {
+    const comp = glslify(source, {
       inline: true,
       basedir: basedir
     });

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function glslifyWebpackLoader(source) {
   this.cacheable(true)
 
   try {
-    const comp = glslify(source, {
+    const comp = glslify.compile(source, {
       inline: true,
       basedir: basedir
     });

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "url": "http://hughsk.io/"
   },
   "dependencies": {
-    "glslify": "^2.1.1"
+    "glslify": "6.1.0"
   },
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git://github.com/stackgl/glslify-loader.git"
+    "url": "git://github.com/maximus8891/glslify-loader.git"
   },
   "keywords": [
     "ecosystem:stackgl"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glslify-loader",
   "version": "1.0.2",
-  "description": "glslify loader module for webpack",
+  "description": "glslify loader module for webpack 3.x",
   "main": "index.js",
   "license": "MIT",
   "scripts": {
@@ -16,10 +16,19 @@
   "dependencies": {
     "glslify": "6.1.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "glsl-aastep": "1.0.1",
+    "glsl-noise": "0.0.0",
+    "glsl-raytrace": "1.0.0",
+    "glsl-sdf-normal": "1.0.0",
+    "glsl-turntable-camera": "1.0.0",
+    "raw-loader": "0.5.1",
+    "webpack": "3.11.0",
+    "webpack-dev-server": "2.11.1"
+  },
   "repository": {
     "type": "git",
-    "url": "git://github.com/maximus8891/glslify-loader.git"
+    "url": "git://github.com/stackgl/glslify-loader.git"
   },
   "keywords": [
     "ecosystem:stackgl"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,17 @@ module.exports = {
     filename: 'bundle.js'
   },
   module: {
-    loaders: [
-      { test: /\.(glsl|frag|vert)$/, loader: 'raw', exclude: /node_modules/ },
-      { test: /\.(glsl|frag|vert)$/, loader: './index', exclude: /node_modules/ }
+    rules: [
+      {
+        test: /\.(glsl|frag|vert)$/, 
+        loader: 'raw-loader', 
+        exclude: /node_modules/
+      },
+      {
+        test: /\.(glsl|frag|vert)$/, 
+        loader: './index', 
+        exclude: /node_modules/
+      }
     ]
   }
 }


### PR DESCRIPTION
This PR is based on https://github.com/maximus8891/glslify-loader, where the latest `glslify` version is used (6.1).

- It fixes `webpack` config so it's compatible with its latest version (**3.x and 4.x!**).
- It also adds webpack and other dev dependencies so there's no need to install them globally when running `start` and/or `bundle` scripts. 
- Finally, it updates the `README` accordingly.

Please let me know if further changes are needed 😄 